### PR TITLE
file_check plug-in arguments fix

### DIFF
--- a/monasca_setup/detection/service_plugin.py
+++ b/monasca_setup/detection/service_plugin.py
@@ -45,7 +45,7 @@ class ServicePlugin(Plugin):
                     if 'process_names' in args_dict:
                         self.process_names = args_dict['process_names'].split(',')
                     if 'file_dirs_names' in args_dict:
-                        self.file_dirs_names = args_dict['file_dirs_names']
+                        self.file_dirs_names = eval(args_dict['file_dirs_names'])
                     if 'directory_names' in args_dict:
                         self.directory_names = args_dict['directory_names'].split(',')
                     if 'service_api_url' in args_dict:


### PR DESCRIPTION
file_check Plug-in arguments
  - monasca-setup -d FileSize -a "file_dirs_names=[('/var/log/heimdall',['\*'],False)]"

In this case "[('/var/log/monasca/agent/',['\*'],True)]" is string.
But the logic is processing the "[('/var/log/monasca/agent/',['\*'],True)]" to the 'List Object'.
So we converted the '[('/var/log/monasca/agent/',['\*'],True)]' to 'List Object'.