### PR TITLE
Add a condition in service detection

### DIFF
--- a/monasca_setup/main.py
+++ b/monasca_setup/main.py
@@ -56,11 +56,12 @@ def main(argv=None):
     if args.dry_run:
         LOG.info("Running in dry run mode, no changes will be made only"
                  " reported")
-
-    # Detect and if possibly enable the agent service
-    agent_service = detect_init(PREFIX_DIR, args.config_dir, args.log_dir,
-                                args.template_dir, username=args.user,
-                                name=args.agent_service_name)
+    # Skip agent service detection if only installing plugins
+    if not args.install_plugins_only:
+        # Detect and if possibly enable the agent service
+        agent_service = detect_init(PREFIX_DIR, args.config_dir, args.log_dir,
+                                    args.template_dir, username=args.user,
+                                    name=args.agent_service_name)
 
     # Skip base setup if only installing plugins or running specific detection
     # plugins


### PR DESCRIPTION
Skip agent service detection if only installing plugins.
This will make it possible to use `monasca-setup` on the environments where monasca-agent is not running as systemd service. Typical usecase is running agent on kubernetes.